### PR TITLE
PLAT-538 Remove Codeconv from GH Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,12 +30,7 @@ jobs:
         run: go vet ./...
 
       - name: Run go test
-        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-      - name: Upload coverage to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
+        run: go test -v -race ./...
 
   windows:
     strategy:


### PR DESCRIPTION
Codeconv was severely compromised by unauthorized modification of their uploader bash script. It's been fixed since then but the way it's been being invoked keeps the same.