### PR TITLE
Add modified_at fields to key struct

### DIFF
--- a/svc_key.go
+++ b/svc_key.go
@@ -46,7 +46,7 @@ type Key struct {
 	BaseWords        int    `json:"base_words"`
 	CharLimit        int    `json:"char_limit"`
 	CustomAttributes string `json:"custom_attributes,omitempty"`
-	
+
 	ModifiedAt   string `json:"modified_at,omitempty"`
 	ModifiedAtTs int64  `json:"modified_at_timestamp,omitempty"`
 }

--- a/svc_key.go
+++ b/svc_key.go
@@ -46,6 +46,9 @@ type Key struct {
 	BaseWords        int    `json:"base_words"`
 	CharLimit        int    `json:"char_limit"`
 	CustomAttributes string `json:"custom_attributes,omitempty"`
+	
+	ModifiedAt   string `json:"modified_at,omitempty"`
+	ModifiedAtTs int64  `json:"modified_at_timestamp,omitempty"`
 }
 
 type PlatformStrings struct {


### PR DESCRIPTION
### Summary

The [API docs](https://app.lokalise.com/api2docs/curl/#object-keys) describe the modified_at and modified_at_timestamp attributes in the key object.  However, the golang Key struct does not contain those fields so that information is lost when parsing the JSON.  This adds the fields so that modification time is available in the struct.

### Other Information

I've tested the changes locally and found that it enables me to see key modification information.  I considered creating a WithModificationTime similar to [WithCreationTime](https://github.com/lokalise/go-lokalise-api/blob/31cbd05cbfb3e053977e4e6735b59b77f6195b3d/service.go#L42-L44) but am not sure if it would be reused.