### PR TITLE
Handle numeric strings translation values properly

### DIFF
--- a/svc_translation.go
+++ b/svc_translation.go
@@ -3,6 +3,7 @@ package lokalise
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
 )
@@ -59,7 +60,11 @@ func (t NewTranslation) MarshalJSON() ([]byte, error) {
 	var translation interface{} = t.Translation
 
 	if json.Valid([]byte(t.Translation)) {
-		_ = json.Unmarshal([]byte(t.Translation), &translation)
+		var unmarshalled map[string]interface{}
+
+		if err := json.Unmarshal([]byte(t.Translation), &unmarshalled); err == nil {
+			translation = unmarshalled
+		}
 	}
 
 	return json.Marshal(&struct {
@@ -122,7 +127,11 @@ func (t UpdateTranslation) MarshalJSON() ([]byte, error) {
 	var translation interface{} = t.Translation
 
 	if json.Valid([]byte(t.Translation)) {
-		_ = json.Unmarshal([]byte(t.Translation), &translation)
+		var unmarshalled map[string]interface{}
+
+		if err := json.Unmarshal([]byte(t.Translation), &unmarshalled); err == nil {
+			translation = unmarshalled
+		}
 	}
 
 	return json.Marshal(&struct {

--- a/svc_translation_test.go
+++ b/svc_translation_test.go
@@ -248,6 +248,43 @@ func TestNewTranslation_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestNewTranslationNumericStrings_MarshalJSON(t *testing.T) {
+	translations := []NewTranslation{
+		{
+			LanguageISO: "en",
+			Translation: "123456",
+		},
+		{
+			LanguageISO: "en",
+			Translation: "{\"one\":\"123456\",\"other\":\"78910\"}",
+		},
+	}
+
+	want := JsonCompact(`
+	[
+		{
+		   "language_iso": "en",
+		   "translation": "123456"
+		},
+		{
+		   "language_iso": "en",
+		   "translation": {
+			  "one": "123456",
+			  "other": "78910"
+		   }
+		}
+ 	]`)
+
+	marshal, err := json.Marshal(translations)
+	if err != nil {
+		t.Errorf("NewTranslation marshalling returned error %s", err)
+	}
+
+	if string(marshal) != want {
+		t.Errorf("NewTranslation marshalling mismatch: %+v, want %+v", string(marshal), want)
+	}
+}
+
 func TestUpdateTranslation_MarshalJSON(t *testing.T) {
 	translations := []UpdateTranslation{
 		{
@@ -267,6 +304,39 @@ func TestUpdateTranslation_MarshalJSON(t *testing.T) {
 		   "translation": {
 			  "one": "oneText",
 			  "other": "otherText"
+		   }
+		}
+ 	]`)
+
+	marshal, err := json.Marshal(translations)
+	if err != nil {
+		t.Errorf("UpdateTranslation marshalling returned error %s", err)
+	}
+
+	if string(marshal) != want {
+		t.Errorf("UpdateTranslation marshalling mismatch: %+v, want %+v", string(marshal), want)
+	}
+}
+
+func TestUpdateTranslationNumericStrings_MarshalJSON(t *testing.T) {
+	translations := []UpdateTranslation{
+		{
+			Translation: "123456",
+		},
+		{
+			Translation: "{\"one\":\"123456\",\"other\":\"78910\"}",
+		},
+	}
+
+	want := JsonCompact(`
+	[
+		{
+		   "translation": "123456"
+		},
+		{
+		   "translation": {
+			  "one": "123456",
+			  "other": "78910"
 		   }
 		}
  	]`)


### PR DESCRIPTION
### Summary

Numeric string like `"1234567"` were marshalled to their `float64` representation when creating/updating translation values, resulting in following error `API request error 400 Expecting ``it`` translation to be a string`.

This fix handles translation value to be in one of possible forms according to API specs: `string` or `map[string]interface{}`