### PR TITLE
Add missing field auto_close_items to Task, CreateTask, UpdateTask

### DIFF
--- a/api.go
+++ b/api.go
@@ -84,7 +84,7 @@ func New(apiToken string, options ...ClientOption) (*Api, error) {
 // WithBaseURL returns a ClientOption setting the base URL of the client.
 // This should only be used for testing different API versions or for using a mocked
 // backend in tests.
-//noinspection GoUnusedExportedFunction
+// noinspection GoUnusedExportedFunction
 func WithBaseURL(url string) ClientOption {
 	return func(c *Api) error {
 		c.httpClient.Client.SetHostURL(url)
@@ -106,7 +106,7 @@ func WithRetryCount(count int) ClientOption {
 
 // Sets default wait time to sleep before retrying request.
 // Default is 100 milliseconds.
-//noinspection GoUnusedExportedFunction
+// noinspection GoUnusedExportedFunction
 func WithRetryTimeout(t time.Duration) ClientOption {
 	return func(c *Api) error {
 		c.httpClient.Client.SetRetryWaitTime(t)

--- a/doc.go
+++ b/doc.go
@@ -11,7 +11,7 @@ Initializing the client
 	token := os.Getenv("lokalise_token")
 	client, err := lokalise.New(token)
 
-General options
+# General options
 
 You can set global API parameters with the ClientOption functions during the initialization. The following functions are available:
 
@@ -35,7 +35,7 @@ Usage:
 		...
 	)
 
-Objects and models
+# Objects and models
 
 Individual objects are represented as instances of according structs. Different objects are used for creating and updating in most cases.
 
@@ -47,7 +47,7 @@ Here are some object types:
 
 * List options that are used for sending certain options and pagination, i.e. KeyListOptions.
 
-Request options and pagination
+# Request options and pagination
 
 Some resources, such as Projects, Keys, Files, Tasks, Screenshots, Translations have optional parameters for List method (Keys also have an option for Retrieve). These parameters should be set before calling.
 
@@ -74,6 +74,5 @@ There are two parameters, used for pagination: Limit and Page.
 	})
 
 	resp, err := t.List()
-
 */
 package lokalise

--- a/svc_task.go
+++ b/svc_task.go
@@ -17,7 +17,7 @@ type TaskService struct {
 // Service entity objects
 // _____________________________________________________________________________________________________________________
 
-//noinspection GoUnusedConst
+// noinspection GoUnusedConst
 const (
 	pathTasks = "tasks"
 

--- a/svc_task.go
+++ b/svc_task.go
@@ -17,7 +17,7 @@ type TaskService struct {
 // Service entity objects
 // _____________________________________________________________________________________________________________________
 
-// noinspection GoUnusedConst
+//noinspection GoUnusedConst
 const (
 	pathTasks = "tasks"
 

--- a/svc_task.go
+++ b/svc_task.go
@@ -17,7 +17,7 @@ type TaskService struct {
 // Service entity objects
 // _____________________________________________________________________________________________________________________
 
-//noinspection GoUnusedConst
+// noinspection GoUnusedConst
 const (
 	pathTasks = "tasks"
 
@@ -60,6 +60,7 @@ type Task struct {
 	Languages                  []TaskLanguage `json:"languages"`
 	AutoCloseLanguages         bool           `json:"auto_close_languages"`
 	AutoCloseTask              bool           `json:"auto_close_task"`
+	AutoCloseItems             bool           `json:"auto_close_items"`
 	CompletedAt                string         `json:"completed_at"`
 	CompletedAtTs              int64          `json:"completed_at_timestamp"`
 	CompletedBy                int64          `json:"completed_by"`
@@ -107,6 +108,7 @@ type CreateTask struct {
 	Keys               []int64  `json:"keys,omitempty"`
 	AutoCloseLanguages *bool    `json:"auto_close_languages,omitempty"`
 	AutoCloseTask      *bool    `json:"auto_close_task,omitempty"`
+	AutoCloseItems     *bool    `json:"auto_close_items,omitempty"`
 	InitialTMLeverage  bool     `json:"initial_tm_leverage,omitempty"`
 	TaskType           TaskType `json:"task_type,omitempty"`
 	ParentTaskID       int64    `json:"parent_task_id,omitempty"`
@@ -130,6 +132,7 @@ type UpdateTask struct {
 	Languages          []CreateTaskLang `json:"languages,omitempty"`
 	AutoCloseLanguages *bool            `json:"auto_close_languages,omitempty"`
 	AutoCloseTask      *bool            `json:"auto_close_task,omitempty"`
+	AutoCloseItems     *bool            `json:"auto_close_items,omitempty"`
 	CloseTask          bool             `json:"close_task,omitempty"`
 	ClosingTags        []string         `json:"closing_tags,omitempty"`
 	LockTranslations   bool             `json:"do_lock_translations,omitempty"`

--- a/svc_task_test.go
+++ b/svc_task_test.go
@@ -36,6 +36,7 @@ func TestTaskService_Create(t *testing.T) {
 				],
 				"auto_close_languages": true,
 				"auto_close_task": true,
+				"auto_close_items": true,
 				"task_type": "translation",
 				"parent_task_id": 12345,
 				"closing_tags": ["tag_one", "tag_two"],
@@ -95,6 +96,7 @@ func TestTaskService_Create(t *testing.T) {
 					],
 					"auto_close_languages": true,
 					"auto_close_task": true,
+					"auto_close_items": true,
 					"completed_at": null,
 					"completed_at_timestamp": null,
 					"completed_by": null,
@@ -115,6 +117,7 @@ func TestTaskService_Create(t *testing.T) {
 		Keys:                       []int64{11212, 11241, 11245},
 		AutoCloseLanguages:         Bool(true),
 		AutoCloseTask:              Bool(true),
+		AutoCloseItems:             Bool(true),
 		TaskType:                   "translation",
 		ParentTaskID:               12345,
 		ClosingTags:                []string{"tag_one", "tag_two"},
@@ -174,6 +177,7 @@ func TestTaskService_Create(t *testing.T) {
 		},
 		AutoCloseLanguages:         true,
 		AutoCloseTask:              true,
+		AutoCloseItems:             true,
 		CompletedAt:                "",
 		CompletedAtTs:              0,
 		CompletedBy:                0,
@@ -304,7 +308,8 @@ func TestTaskService_Update(t *testing.T) {
 			data := `{
 				"due_date": "2019-12-31 12:00:00",
 				"auto_close_languages": false,
-				"auto_close_task": false
+				"auto_close_task": false,
+				"auto_close_items": false
 			}`
 
 			req := new(bytes.Buffer)
@@ -324,6 +329,7 @@ func TestTaskService_Update(t *testing.T) {
 		DueDate:            "2019-12-31 12:00:00",
 		AutoCloseLanguages: Bool(false),
 		AutoCloseTask:      Bool(false),
+		AutoCloseItems:     Bool(false),
 	})
 	if err != nil {
 		t.Errorf("Tasks.Update returned error: %v", err)

--- a/svc_teamuser.go
+++ b/svc_teamuser.go
@@ -12,7 +12,7 @@ type TeamUserService struct {
 // Service entity objects
 // _____________________________________________________________________________________________________________________
 
-//noinspection GoUnusedConst
+// noinspection GoUnusedConst
 const (
 	TeamUserRoleOwner  TeamUserRole = "owner"
 	TeamUserRoleAdmin  TeamUserRole = "admin"


### PR DESCRIPTION
### Summary

`auto_close_items` field is there in official [documentation](https://developers.lokalise.com/reference/tasks-object) but Golang library don't have that field.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.