### PR TITLE
Add Compact to the FileDownload struct

### DIFF
--- a/svc_file.go
+++ b/svc_file.go
@@ -87,6 +87,7 @@ type FileDownload struct {
 	JavaPropertiesEncoding     string            `json:"java_properties_encoding,omitempty"`
 	JavaPropertiesSeparator    string            `json:"java_properties_separator,omitempty"`
 	BundleDescription          string            `json:"bundle_description,omitempty"`
+	Compact                    bool              `json:"compact,omitempty"`
 }
 
 type LanguageMapping struct {


### PR DESCRIPTION
### Summary

This PR adds the Compact key to the FileDownload struct. This can be used to eventually close https://github.com/lokalise/lokalise-cli-2-go/issues/100, I'm planning to open a PR for that as well.

### Other Information