### PR TITLE
Add the payment_method field to Order

### DIFF
--- a/svc_order.go
+++ b/svc_order.go
@@ -23,7 +23,7 @@ type Order struct {
 
 	OrderID             string           `json:"order_id"`
 	CardID              int64            `json:"card_id"`
-	PaymentMethod	  	string   		 `json:"payment_method"`
+	PaymentMethod       string           `json:"payment_method"`
 	Status              string           `json:"status"`
 	SourceLangISO       string           `json:"source_language_iso"`
 	TargetLangISOs      []string         `json:"target_language_isos"`
@@ -44,7 +44,7 @@ type Order struct {
 type CreateOrder struct {
 	ProjectID         string   `json:"project_id"`
 	CardID            int64    `json:"card_id"`
-	PaymentMethod	  string   `json:"payment_method"`
+	PaymentMethod     string   `json:"payment_method"`
 	Briefing          string   `json:"briefing"`
 	SourceLangISO     string   `json:"source_language_iso"`
 	TargetLangISOs    []string `json:"target_language_isos"`

--- a/svc_order.go
+++ b/svc_order.go
@@ -23,6 +23,7 @@ type Order struct {
 
 	OrderID             string           `json:"order_id"`
 	CardID              int64            `json:"card_id"`
+	PaymentMethod	  	string   		 `json:"payment_method"`
 	Status              string           `json:"status"`
 	SourceLangISO       string           `json:"source_language_iso"`
 	TargetLangISOs      []string         `json:"target_language_isos"`
@@ -43,6 +44,7 @@ type Order struct {
 type CreateOrder struct {
 	ProjectID         string   `json:"project_id"`
 	CardID            int64    `json:"card_id"`
+	PaymentMethod	  string   `json:"payment_method"`
 	Briefing          string   `json:"briefing"`
 	SourceLangISO     string   `json:"source_language_iso"`
 	TargetLangISOs    []string `json:"target_language_isos"`

--- a/svc_order_test.go
+++ b/svc_order_test.go
@@ -22,6 +22,7 @@ func TestOrderService_Create(t *testing.T) {
 			data := `{
 				"project_id": "` + testProjectID + `",
 				"card_id": 12345,
+				"payment_method": "credit_card",
 				"briefing": "Terms of use of our app.",
 				"source_language_iso": "en_US",
 				"target_language_isos": [
@@ -47,6 +48,7 @@ func TestOrderService_Create(t *testing.T) {
 			_, _ = fmt.Fprint(w, `{
 				"order_id": "20181231AAAA",
 				"project_id": "`+testProjectID+`",
+				"payment_method": "credit_card",
 				"card_id": 12345,
 				"status": "in progress",
 				"created_at": "2018-12-31 12:00:00 (Etc/UTC)",
@@ -82,6 +84,7 @@ func TestOrderService_Create(t *testing.T) {
 
 	r, err := client.Orders().Create(1, CreateOrder{
 		ProjectID:         testProjectID,
+		PaymentMethod: 	   "credit_card",
 		CardID:            12345,
 		Briefing:          "Terms of use of our app.",
 		SourceLangISO:     "en_US",
@@ -107,6 +110,7 @@ func TestOrderService_Create(t *testing.T) {
 			CreatedByEmail: "jonn@company.com",
 		},
 		OrderID:       "20181231AAAA",
+		PaymentMethod: "credit_card",
 		CardID:        12345,
 		Status:        "in progress",
 		SourceLangISO: "en_US",

--- a/svc_order_test.go
+++ b/svc_order_test.go
@@ -84,7 +84,7 @@ func TestOrderService_Create(t *testing.T) {
 
 	r, err := client.Orders().Create(1, CreateOrder{
 		ProjectID:         testProjectID,
-		PaymentMethod: 	   "credit_card",
+		PaymentMethod:     "credit_card",
 		CardID:            12345,
 		Briefing:          "Terms of use of our app.",
 		SourceLangISO:     "en_US",

--- a/svc_order_test.go
+++ b/svc_order_test.go
@@ -191,7 +191,8 @@ func TestOrderService_Retrieve(t *testing.T) {
 			testHeader(t, r, apiTokenHeader, testApiToken)
 
 			_, _ = fmt.Fprint(w, `{
-				"order_id": "20181231AAAA"
+				"order_id": "20181231AAAA",
+				"payment_method": "credit_card"
 			}`)
 		})
 
@@ -201,7 +202,8 @@ func TestOrderService_Retrieve(t *testing.T) {
 	}
 
 	want := Order{
-		OrderID: "20181231AAAA",
+		OrderID:       "20181231AAAA",
+		PaymentMethod: "credit_card",
 	}
 
 	if !reflect.DeepEqual(r, want) {


### PR DESCRIPTION
### Summary

Added the `payment_method` field which already exists in the [documentation ](https://developers.lokalise.com/reference/create-an-order) and the Node client but just wasn't added yet to the Go client.

### Other Information

We'll be using this field to enable the use of `payment_method: team_credit` at Samsara.