### PR TITLE
Add option to customize HTTP transport used in API

### DIFF
--- a/api.go
+++ b/api.go
@@ -135,7 +135,7 @@ func WithDebug(dbg bool) ClientOption {
 
 func WithTransport(rt http.RoundTripper) ClientOption {
 	return func(c *Api) error {
-		c.httpClient.Client.SetTransport(rt)
+		c.httpClient.SetTransport(rt)
 		return nil
 	}
 }

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package lokalise
 
 import (
 	"errors"
+	"net/http"
 	"time"
 )
 
@@ -128,6 +129,13 @@ func WithConnectionTimeout(t time.Duration) ClientOption {
 func WithDebug(dbg bool) ClientOption {
 	return func(c *Api) error {
 		c.httpClient.Client.SetDebug(dbg)
+		return nil
+	}
+}
+
+func WithTransport(rt http.RoundTripper) ClientOption {
+	return func(c *Api) error {
+		c.httpClient.Client.SetTransport(rt)
 		return nil
 	}
 }


### PR DESCRIPTION
### Summary

Added option to use custom RoundTripper for Api. 
Sometimes it is very useful, when you need to wrap transport by any middlewares to do proper observability tracking.
