### PR TITLE
PERF-1400 Add warning on `Export too big`

### DIFF
--- a/service.go
+++ b/service.go
@@ -67,3 +67,7 @@ type WithProjectID struct {
 type WithUserID struct {
 	UserID int64 `json:"user_id,omitempty"`
 }
+
+type WithWarning struct {
+	Warning string
+}

--- a/svc_file.go
+++ b/svc_file.go
@@ -2,9 +2,8 @@ package lokalise
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
-
 	"github.com/go-resty/resty/v2"
+	"github.com/google/go-querystring/query"
 )
 
 const (
@@ -111,6 +110,7 @@ type FileUploadResponse struct {
 
 type FileDownloadResponse struct {
 	WithProjectID
+	WithWarning
 	BundleURL string `json:"bundle_url"`
 }
 
@@ -160,6 +160,9 @@ func (c *FileService) Download(projectID string, downloadOptions FileDownload) (
 	if err != nil {
 		return
 	}
+
+	r.Warning = resp.Header().Get("X-Response-Too-Big")
+
 	return r, apiError(resp)
 }
 


### PR DESCRIPTION
### Summary

Added Warning field on FileDownloadResponse on received header `X-Response-Too-Big`.
