### PR TITLE
Update workflow runner to go 1.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   linux:
     strategy:
       matrix:
-        go-version: [1.x, 1.12.x]
+        go-version: [1.x, 1.13.x]
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +35,7 @@ jobs:
   windows:
     strategy:
       matrix:
-        go-version: [1.x, 1.12.x]
+        go-version: [1.x, 1.13.x]
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
### Summary

Update tests workflow runner to 1.13 as per go.mod specs.