### PR TITLE
PERF-1891 CLI: 'details' object empty when retrieving a process for uploaded file

### DIFF
--- a/svc_queuedprocesses.go
+++ b/svc_queuedprocesses.go
@@ -17,11 +17,24 @@ type QueuedProcessService struct {
 // _____________________________________________________________________________________________________________________
 
 type ProcessDetails struct {
-	ItemsToProcess *int   `json:"items_to_process,omitempty"`
-	ItemsProcessed *int   `json:"items_processed,omitempty"`
-	DownloadUrl    string `json:"download_url,omitempty"`
-	Progress       string `json:"progress,omitempty"`
-	Stage          string `json:"stage,omitempty"`
+	ItemsToProcess *int                 `json:"items_to_process,omitempty"`
+	ItemsProcessed *int                 `json:"items_processed,omitempty"`
+	DownloadUrl    string               `json:"download_url,omitempty"`
+	Progress       string               `json:"progress,omitempty"`
+	Stage          string               `json:"stage,omitempty"`
+	Files          []ProcessDetailsFile `json:"files,omitempty"`
+}
+
+type ProcessDetailsFile struct {
+	Status           string `json:"status"`
+	Message          string `json:"message"`
+	NameOriginal     string `json:"name_original"`
+	NameCustom       string `json:"name_custom"`
+	WordCountTotal   int    `json:"word_count_total"`
+	KeyCountTotal    int    `json:"key_count_total"`
+	KeyCountInserted int    `json:"key_count_inserted"`
+	KeyCountUpdated  int    `json:"key_count_updated"`
+	KeyCountSkipped  int    `json:"key_count_skipped"`
 }
 
 type QueuedProcess struct {

--- a/svc_queuedprocesses_test.go
+++ b/svc_queuedprocesses_test.go
@@ -85,7 +85,22 @@ func TestQueuedProcessService_Retrieve(t *testing.T) {
 					"created_by": 1234,
 					"created_by_email": "example@example.com",
 					"created_at": "2020-04-20 13:43:43 (Etc/UTC)",
-					"created_at_timestamp": 1587390223
+					"created_at_timestamp": 1587390223,
+					"details": {
+						"files": [
+							{
+								"status": "finished",
+								"message": "",
+								"name_original": "index.json",
+								"name_custom": "index.json",
+								"word_count_total": 2,
+								"key_count_total": 1,
+								"key_count_inserted": 0,
+								"key_count_updated": 0,
+								"key_count_skipped": 1
+							}
+						]
+					}
 				}
 			}`)
 		})
@@ -100,6 +115,21 @@ func TestQueuedProcessService_Retrieve(t *testing.T) {
 		Type:    "file-import",
 		Status:  "finished",
 		Message: "",
+		Details: ProcessDetails{
+			Files: []ProcessDetailsFile{
+				{
+					Status:           "finished",
+					Message:          "",
+					NameOriginal:     "index.json",
+					NameCustom:       "index.json",
+					WordCountTotal:   2,
+					KeyCountTotal:    1,
+					KeyCountInserted: 0,
+					KeyCountUpdated:  0,
+					KeyCountSkipped:  1,
+				},
+			},
+		},
 		WithCreationUser: WithCreationUser{
 			CreatedBy:      1234,
 			CreatedByEmail: "example@example.com",


### PR DESCRIPTION
### Summary

Populate details for queued processes (e.g. file-import), which was previously always empty.

  - Added ProcessDetailsFile struct representing per-file import results (status, message, name_original, name_custom, word_count_total, key_count_total, key_count_inserted, key_count_updated, key_count_skipped).
  - Added Files []ProcessDetailsFile field to ProcessDetails so the API's details.files array is now deserialized instead of being dropped.
  - Extended TestQueuedProcessService_Retrieve to cover a response containing details.files and assert it's parsed correctly.